### PR TITLE
Remove RFP 'Speakers' section from header.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ exclude:
 
 visible:
   sponsors: true
-  speaking: true
+  speaking: false
   speakers: true
   schedule: false
-


### PR DESCRIPTION
Since RFP is over, makes sense to declutter header, particularly when it's as simple as toggling setting.